### PR TITLE
chore: sync framework @ 1.2.7

### DIFF
--- a/.devcontainer/Makefile
+++ b/.devcontainer/Makefile
@@ -1,0 +1,71 @@
+# Thin Makefile — bootstraps the framework cache and delegates to makefile.sh
+# The actual build/run logic lives in the framework (pulled at FRAMEWORK_VERSION).
+# For local Docker usage: cd .devcontainer && make start
+
+FRAMEWORK_VERSION := $(shell grep -oP ':-\K[^}"]+' util/source_framework.sh | head -1)
+CACHE := .cache/dt-framework/$(FRAMEWORK_VERSION)
+
+# Repo name and root path (CURDIR = repo/.devcontainer where this Makefile lives)
+REPO_NAME := $(notdir $(patsubst %/,%,$(dir $(CURDIR))))
+REPO_ROOT := $(patsubst %/,%,$(dir $(CURDIR)))
+
+# Bootstrap: populate host cache if missing
+$(CACHE)/.complete:
+	@echo "Bootstrapping framework v$(FRAMEWORK_VERSION)..."
+	@mkdir -p $(dir $(CACHE))
+	@git clone --depth 1 --filter=blob:none --sparse \
+		-b $(FRAMEWORK_VERSION) \
+		https://github.com/dynatrace-wwse/codespaces-framework.git \
+		$(CACHE) 2>/dev/null
+	@cd $(CACHE) && git sparse-checkout set --no-cone \
+		'.devcontainer/util/*' \
+		'.devcontainer/p10k/*' \
+		'.devcontainer/test/*' \
+		'.devcontainer/apps/*' \
+		'/.devcontainer/Makefile' \
+		'/.devcontainer/makefile.sh' \
+		'.devcontainer/runlocal/*' \
+		'/.devcontainer/Dockerfile' \
+		'/.devcontainer/entrypoint.sh' \
+		'.devcontainer/yaml/*'
+	@touch $(CACHE)/.complete
+	@# Write a wrapper that sources makefile.sh safely in cache mode:
+	@# - strips top-level calls to getRepositoryName/getDockerEnvsFromEnvFile
+	@# - sets ENV_FILE and RepositoryName to the repo's paths
+	@# - re-sources helper.sh and calls getDockerEnvsFromEnvFile
+	@printf '#!/bin/bash\n\
+export ENV_FILE="$(CURDIR)/.env"\n\
+export RepositoryName="$(REPO_NAME)"\n\
+_MAKEFILE_DIR="$$(cd "$$(dirname "$${BASH_SOURCE[0]}")" && pwd)"\n\
+eval "$$(sed "/^getRepositoryName$$/d; /^getDockerEnvsFromEnvFile$$/d" "$${_MAKEFILE_DIR}/makefile.sh")"\n\
+export ENV_FILE="$(CURDIR)/.env"\n\
+export RepositoryName="$(REPO_NAME)"\n\
+VOLUMEMOUNTS="-v /var/run/docker.sock:/var/run/docker.sock -v /lib/modules:/lib/modules -v $(REPO_ROOT):/workspaces/$(REPO_NAME)"\n\
+WORKINGDIR="-w /workspaces/$(REPO_NAME)"\n\
+source "$${_MAKEFILE_DIR}/runlocal/helper.sh"\n\
+getDockerEnvsFromEnvFile\n' > $(CACHE)/.devcontainer/cached_makefile.sh
+	@echo "Framework v$(FRAMEWORK_VERSION) cached."
+
+start: $(CACHE)/.complete
+	@cd $(CACHE)/.devcontainer && bash -c 'source cached_makefile.sh; start'
+
+build: $(CACHE)/.complete
+	@cd $(CACHE)/.devcontainer && bash -c 'source cached_makefile.sh; build'
+
+build-nocache: $(CACHE)/.complete
+	@cd $(CACHE)/.devcontainer && bash -c 'source cached_makefile.sh; buildNoCache'
+
+buildx: $(CACHE)/.complete
+	@cd $(CACHE)/.devcontainer && bash -c 'source cached_makefile.sh; buildx'
+
+integration: $(CACHE)/.complete
+	@cd $(CACHE)/.devcontainer && bash -c 'source cached_makefile.sh; integration'
+
+clean-cache:
+	@rm -rf .cache/dt-framework
+	@echo "Framework cache cleared."
+
+clean-start: clean-cache
+	@docker kill $$(docker ps -q) 2>/dev/null; docker rm $$(docker ps -aq) 2>/dev/null; true
+	@echo "Containers removed."
+	@$(MAKE) start

--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Versioned framework pull mechanism
+# sync push-update updates the FRAMEWORK_VERSION line only.
+#
+# Two modes:
+#   DEV MODE:   Local functions.sh exists -> source directly (for codespaces-framework development)
+#   CACHE MODE: No local files -> two-tier cache (host cache -> container cache -> git clone)
+#
+# Two-tier cache:
+#   HOST_CACHE:      $REPO_PATH/.devcontainer/.cache/dt-framework/<version>/
+#                    Lives inside the volume-mounted repo dir -> persists across container rebuilds
+#   CONTAINER_CACHE: $HOME/.cache/dt-framework/<version>/
+#                    Local to the container -> fast access, lost on container rebuild
+
+# Framework version pin — sync push-update updates this line
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.2.7}"
+
+REPO_PATH="$(pwd)"
+RepositoryName="$(basename "$REPO_PATH")"
+
+# -- DEV MODE: local files exist -> source directly, no cache --
+if [ -f "${REPO_PATH}/.devcontainer/util/functions.sh" ]; then
+  FRAMEWORK_CACHE=""
+  FRAMEWORK_APPS_PATH="${REPO_PATH}/.devcontainer/apps"
+  export FRAMEWORK_VERSION REPO_PATH RepositoryName FRAMEWORK_CACHE FRAMEWORK_APPS_PATH
+
+  source "${REPO_PATH}/.devcontainer/util/functions.sh"
+  return 0 2>/dev/null || exit 0
+fi
+
+# -- CACHE MODE: enablement repo (no local framework files) --
+HOST_CACHE="${REPO_PATH}/.devcontainer/.cache/dt-framework/${FRAMEWORK_VERSION}"
+CONTAINER_CACHE="${HOME}/.cache/dt-framework/${FRAMEWORK_VERSION}"
+FRAMEWORK_CACHE="${CONTAINER_CACHE}"
+FRAMEWORK_APPS_PATH="${FRAMEWORK_CACHE}/.devcontainer/apps"
+export FRAMEWORK_VERSION REPO_PATH RepositoryName FRAMEWORK_CACHE FRAMEWORK_APPS_PATH
+
+# Tier 1: Container cache exists -> use it directly
+if [ -f "${CONTAINER_CACHE}/.complete" ]; then
+  source "${FRAMEWORK_CACHE}/.devcontainer/util/functions.sh"
+  return 0 2>/dev/null || exit 0
+fi
+
+# Tier 2: Host cache exists -> copy to container cache
+if [ -f "${HOST_CACHE}/.complete" ]; then
+  echo "Copying framework v${FRAMEWORK_VERSION} from host cache..."
+  mkdir -p "${CONTAINER_CACHE}"
+  cp -a "${HOST_CACHE}/." "${CONTAINER_CACHE}/"
+  source "${FRAMEWORK_CACHE}/.devcontainer/util/functions.sh"
+  return 0 2>/dev/null || exit 0
+fi
+
+# Tier 3: Neither cache exists -> git clone into host cache, then copy to container cache
+echo "Pulling framework v${FRAMEWORK_VERSION}..."
+if ! (
+  mkdir -p "$(dirname "${HOST_CACHE}")" && \
+  git clone --depth 1 --filter=blob:none --sparse \
+    -b "${FRAMEWORK_VERSION}" \
+    https://github.com/dynatrace-wwse/codespaces-framework.git \
+    "${HOST_CACHE}" 2>/dev/null && \
+  cd "${HOST_CACHE}" && \
+  git sparse-checkout set --no-cone \
+    '.devcontainer/util/*' \
+    '.devcontainer/p10k/*' \
+    '/.devcontainer/test/test_functions.sh' \
+    '.devcontainer/apps/*' \
+    '/.devcontainer/Makefile' \
+    '/.devcontainer/makefile.sh' \
+    '.devcontainer/runlocal/*' \
+    '/.devcontainer/Dockerfile' \
+    '/.devcontainer/entrypoint.sh' \
+    '.devcontainer/yaml/*' && \
+  touch "${HOST_CACHE}/.complete"
+); then
+  echo "Failed to pull framework v${FRAMEWORK_VERSION} -- check network and retry"
+  return 1 2>/dev/null || exit 1
+fi
+
+# Copy host cache to container cache
+mkdir -p "${CONTAINER_CACHE}"
+cp -a "${HOST_CACHE}/." "${CONTAINER_CACHE}/"
+
+source "${FRAMEWORK_CACHE}/.devcontainer/util/functions.sh"


### PR DESCRIPTION
## Sync update

- Initial migration to versioned pull model at `1.2.7`.
- Updates templates (`source_framework.sh`, `Makefile`).
- Removes framework-owned files (Category A) — now pulled from cache.

Auto-generated by `sync push-update`.