### PR TITLE
chore: sync framework @ 1.3.0

### DIFF
--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.2.7}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.0}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ __pycache__/
 
 # Temporary Dockerfile from cache for local builds
 Dockerfile.framework
+
+
+# Framework runtime files
+.devcontainer/util/.count*


### PR DESCRIPTION
## Sync update

- Bumps `FRAMEWORK_VERSION` from `1.2.7` to `1.3.0`.
- Updates templates (`source_framework.sh`, `Makefile`).
- Removes framework-owned files (Category A) — now pulled from cache.

Auto-generated by `sync push-update`.