### PR TITLE
docs: remove per-page JS RUM snippets, update main.html for auto page tracking

### DIFF
--- a/docs/bizevents.md
+++ b/docs/bizevents.md
@@ -1,4 +1,3 @@
---8<-- "snippets/bizevents.js"
 
 # Business Events — Trading Data Analysis
 

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -1,4 +1,3 @@
---8<-- "snippets/copilot.js"
 
 # CoPilot — AI-Assisted DQL
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,4 +1,3 @@
---8<-- "snippets/events.js"
 
 # Events — Problems, Entities, Vulnerabilities
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,3 @@
---8<-- "snippets/getting-started.js"
 
 --8<-- "snippets/disclaimer.md"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
---8<-- "snippets/index.js"
 
 --8<-- "snippets/disclaimer.md"
 

--- a/docs/logs-part-1.md
+++ b/docs/logs-part-1.md
@@ -1,4 +1,3 @@
---8<-- "snippets/logs-part-1.js"
 
 # Logs Part 1 — Fetch, Filter, Timeframes
 

--- a/docs/logs-part-2.md
+++ b/docs/logs-part-2.md
@@ -1,4 +1,3 @@
---8<-- "snippets/logs-part-2.js"
 
 # Logs Part 2 — Summarize, Aggregate, Sort
 

--- a/docs/logs-part-3.md
+++ b/docs/logs-part-3.md
@@ -1,4 +1,3 @@
---8<-- "snippets/logs-part-3.js"
 
 # Logs Part 3 — Parse, Extract, Visualize
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,4 +1,3 @@
---8<-- "snippets/metrics.js"
 
 # Metrics — Timeseries, CPU, Forecasting
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,3 +8,16 @@
     crossorigin="anonymous"></script>
   {% endif %}
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if config.extra.rum_snippet and page is defined and page.title %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      if (typeof dynatrace !== 'undefined') {
+        dynatrace.sendBizEvent('page_load', {'page': {{ page.title | tojson }}});
+      }
+    });
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,4 +1,3 @@
---8<-- "snippets/resources.js"
 
 # Resources
 

--- a/docs/snippets/bizevents.js
+++ b/docs/snippets/bizevents.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "8. Business Events"});
-});
-</script>

--- a/docs/snippets/copilot.js
+++ b/docs/snippets/copilot.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "9. CoPilot"});
-});
-</script>

--- a/docs/snippets/events.js
+++ b/docs/snippets/events.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "7. Events"});
-});
-</script>

--- a/docs/snippets/getting-started.js
+++ b/docs/snippets/getting-started.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "2. Getting Started"});
-});
-</script>

--- a/docs/snippets/index.js
+++ b/docs/snippets/index.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "1. About"});
-});
-</script>

--- a/docs/snippets/logs-part-1.js
+++ b/docs/snippets/logs-part-1.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "3. Logs Part 1"});
-});
-</script>

--- a/docs/snippets/logs-part-2.js
+++ b/docs/snippets/logs-part-2.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "4. Logs Part 2"});
-});
-</script>

--- a/docs/snippets/logs-part-3.js
+++ b/docs/snippets/logs-part-3.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "5. Logs Part 3"});
-});
-</script>

--- a/docs/snippets/metrics.js
+++ b/docs/snippets/metrics.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "6. Metrics"});
-});
-</script>

--- a/docs/snippets/resources.js
+++ b/docs/snippets/resources.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "11. Resources"});
-});
-</script>

--- a/docs/snippets/use-cases.js
+++ b/docs/snippets/use-cases.js
@@ -1,5 +1,0 @@
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  dynatrace.sendBizEvent('page_load', {"page": "10. Use Cases"});
-});
-</script>

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,4 +1,3 @@
---8<-- "snippets/use-cases.js"
 
 # Use Cases — Real-World DQL Scenarios
 


### PR DESCRIPTION
## Summary

- Removes all `docs/snippets/*.js` files (per-page RUM bizEvent scripts)
- Removes `--8<-- "snippets/*.js"` includes from all markdown pages
- Updates `docs/overrides/main.html` to the framework v1.3.0 template

## Why

Page tracking via BizEvents is now handled centrally by `docs/overrides/main.html`, which:
1. Loads the RUM agent from `extra.rum_snippet` in `mkdocs.yaml`
2. Fires a `page_load` BizEvent on every page using the page title from the `nav` definition

Per-page JS snippet files were redundant and required manual maintenance for each new page.

## Test plan
- [ ] Verify docs build succeeds in CI
- [ ] Confirm no broken snippet includes remain in markdown files

🤖 Generated with [Claude Code](https://claude.com/claude-code)