### PR TITLE
chore: sync framework @ 1.4.0

### DIFF
--- a/.devcontainer/util/source_framework.sh
+++ b/.devcontainer/util/source_framework.sh
@@ -13,7 +13,7 @@
 #                    Local to the container -> fast access, lost on container rebuild
 
 # Framework version pin — sync push-update updates this line
-FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.3.4}"
+FRAMEWORK_VERSION="${FRAMEWORK_VERSION:-1.4.0}"
 
 REPO_PATH="$(pwd)"
 RepositoryName="$(basename "$REPO_PATH")"


### PR DESCRIPTION
## Sync update

- Bumps `FRAMEWORK_VERSION` from `1.3.4` to `1.4.0`.
- Updates templates (`source_framework.sh`, `Makefile`).
- Removes framework-owned files (Category A) — now pulled from cache.

Auto-generated by `sync push-update`.